### PR TITLE
Image update

### DIFF
--- a/image.go
+++ b/image.go
@@ -168,11 +168,60 @@ func (image *Image) Delete() error {
 }
 
 // Update will update the image on OpenNebula
-func (image *Image) Update(template string, merge bool) error {
-	mergeInt := 0
-	if merge {
-		mergeInt = 1
+func (image *Image) Update(template string, merge int) error {
+	_, err := client.Call("one.image.update", image.ID, template, merge)
+	return err
+}
+
+// ImageChmodOptions is the options set for the chmod() API call
+type ImageChmodOptions struct {
+	UserUse     int
+	UserManage  int
+	UserAdmin   int
+	GroupUse    int
+	GroupManage int
+	GroupAdmin  int
+	OtherUse    int
+	OtherManage int
+	OtherAdmin  int
+}
+
+// NewImageChmodOptions returns ACL options for an image template initialized
+// with "no op" values.
+// See https://docs.opennebula.org/<version>/integration/system_interfaces/api.html#actions-for-image-management
+// for more informations
+func NewImageChmodOptions() ImageChmodOptions {
+	return ImageChmodOptions{
+		UserUse:     -1,
+		UserManage:  -1,
+		UserAdmin:   -1,
+		GroupUse:    -1,
+		GroupManage: -1,
+		GroupAdmin:  -1,
+		OtherUse:    -1,
+		OtherManage: -1,
+		OtherAdmin:  -1,
 	}
-	_, err := client.Call("one.image.update", image.ID, template, mergeInt)
+}
+
+// Chmod will change the ACL of the image template on OpenNebula
+func (image *Image) Chmod(opts ImageChmodOptions) error {
+	_, err := client.Call("one.image.chmod", image.ID,
+		opts.UserUse,
+		opts.UserManage,
+		opts.UserAdmin,
+		opts.GroupUse,
+		opts.GroupManage,
+		opts.GroupAdmin,
+		opts.OtherUse,
+		opts.OtherManage,
+		opts.OtherAdmin,
+	)
+	return err
+}
+
+// Chown will change the owner of the image template on OpenNebula
+func (image *Image) Chown(userId, groupId int) error {
+	_, err := client.Call("one.image.chown", image.ID, userId, groupId)
 	return err
 }

--- a/image.go
+++ b/image.go
@@ -166,3 +166,13 @@ func (image *Image) Delete() error {
 	_, err := client.Call("one.image.delete", image.ID)
 	return err
 }
+
+// Update will update the image on OpenNebula
+func (image *Image) Update(template string, merge bool) error {
+	mergeInt := 0
+	if merge {
+		mergeInt = 1
+	}
+	_, err := client.Call("one.image.update", image.ID, template, mergeInt)
+	return err
+}


### PR DESCRIPTION
I'm working to ensure there will be documented/working packer support for ONE.
Turns out someone (by name of Wiliam Petit?) had made apparently made a working solution but told noone about it.

See, there's a packer post-processor for OpenNebula:
[Cadoles/packer-opennebula](https://forge.cadoles.com/Cadoles/packer-opennebula)

In the go build deps I also found reference to a fork of goca including the branch `image-update` in this PR.
From what I can see it wasn't ever made a PR, so even with my limitations of not knowing anything about go, or goca and not being the author: *here you go.*
The PR basically seems to just implement permission management (chown/chmod) on images. I've not spotted any bad style or questionable behaviour.

**Please** could you give this snippet a review for sense-making and merge-ability?  
I really want to get this to back to life before the code rot is unsolvable.

Personally I can see a long chain of features attached to this (combining working function of packer, terraform, vagrant... is more than just the sum of the parts.)